### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ passwd
 pacman -S grub
 ```
 
-### Install EFI Boot manager
+### Install EFI Boot manager (UEFI)
 ```
 pacman -S efibootmgr
 ```

--- a/README.md
+++ b/README.md
@@ -276,6 +276,11 @@ passwd
 pacman -S grub
 ```
 
+### Install EFI Boot manager
+```
+pacman -S efibootmgr
+```
+
 #### For UEFI System
 ```
 grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=GRUB


### PR DESCRIPTION
On a UEFI system, it is required to install efibootmgr or the grub install will fail. Added command for installing: pacman -S efibootmgr